### PR TITLE
Fix SIC extraction for cell types with shared prefixes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          upgrade: TRUE
+          upgrade: 'TRUE'
           extra-packages: |
             any::testthat
             any::devtools

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          upgrade: TRUE
           extra-packages: |
             any::testthat
             any::devtools

--- a/R/sic_extraction.R
+++ b/R/sic_extraction.R
@@ -153,8 +153,9 @@ compute_sic_posterior <- function(fit,
   for (group_i in indices) {
     for (source in source_types) {
       # Find coefficient indices for this target-source pair
-      coef_pattern <- paste0("_", target_type, "_", source)
-      coef_ix <- grep(coef_pattern, coef_names, fixed = TRUE)
+      # Use $ anchor to match exact source name at end (avoids matching cd4tcells_ICOS when looking for cd4tcells)
+      coef_pattern <- paste0("_", target_type, "_", source, "$")
+      coef_ix <- grep(coef_pattern, coef_names)
 
       if (length(coef_ix) == 0) {
         warning(sprintf("No coefficients found for %s -> %s", source, target_type))
@@ -221,8 +222,9 @@ compute_sic_posterior <- function(fit,
   for (patient_i in indices) {
     for (source in source_types) {
       # Find coefficient indices for this target-source pair
-      coef_pattern <- paste0("_", target_type, "_", source)
-      coef_ix <- grep(coef_pattern, coef_names, fixed = TRUE)
+      # Use $ anchor to match exact source name at end (avoids matching cd4tcells_ICOS when looking for cd4tcells)
+      coef_pattern <- paste0("_", target_type, "_", source, "$")
+      coef_ix <- grep(coef_pattern, coef_names)
 
       if (length(coef_ix) == 0) {
         warning(sprintf("No coefficients found for %s -> %s", source, target_type))
@@ -283,8 +285,9 @@ compute_sic_posterior <- function(fit,
   for (image_i in indices) {
     for (source in source_types) {
       # Find coefficient indices for this target-source pair
-      coef_pattern <- paste0("_", target_type, "_", source)
-      coef_ix <- grep(coef_pattern, coef_names, fixed = TRUE)
+      # Use $ anchor to match exact source name at end (avoids matching cd4tcells_ICOS when looking for cd4tcells)
+      coef_pattern <- paste0("_", target_type, "_", source, "$")
+      coef_ix <- grep(coef_pattern, coef_names)
 
       if (length(coef_ix) == 0) {
         warning(sprintf("No coefficients found for %s -> %s", source, target_type))


### PR DESCRIPTION
## Summary

Fixes the `mul.tensor: i incompatible to j` error when extracting SICs from datasets where one cell type name is a prefix of another (e.g., `cd4tcells`, `cd4tcells_ICOS`, `cd4tcells_PD1`).

- Changed coefficient name matching from substring search to exact end-of-string match using regex `$` anchor
- Applied fix to all three extraction functions: `.extract_group_sics()`, `.extract_patient_sics()`, `.extract_image_sics()`

Fixes #5